### PR TITLE
First draft

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,61 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install Python dependencies
+        run: |
+          pip install requests
+      - name: Install executables
+        uses: ./
+        with:
+          path: ~/.local/bin
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check executables
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/verify_install.py ~/.local/bin
+  test_windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install Python dependencies
+        run: |
+          pip install requests
+      - name: Install executables
+        uses: ./
+        with:
+          path: C:\Users\runneradmin\.local\bin
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check executables
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/verify_install.py C:\Users\runneradmin\.local\bin

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin-release/
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.
+
+# IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # install-modflow-action
-action to install MODFLOW-based executables
+
+[![CI](https://github.com/modflowpy/install-modflow-action/actions/workflows/commit.yml/badge.svg?branch=develop)](https://github.com/modflowpy/install-modflow-action/actions/workflows/commit.yml)
+![Status](https://img.shields.io/badge/-under%20development-yellow?style=flat-square)
+
+An action to install executables for MODFLOW and related programs from the [executables distribution repository](https://github.com/MODFLOW-USGS/executables).
+
+## Usage
+
+To use this action, add a step like the following to your workflow:
+
+```yaml
+- name: Install executables
+  uses: modflowpy/install-modflow-action@v1
+  with:
+      path: ~/.local/bin
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Note that tilde expansion works on Linux and Mac runners, but not on Windows &mdash; the corresponding location on Windows is `C:\Users\runneradmin\.local\bin`.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,123 @@
+name: Install MODFLOW executables
+description: Install & cache MODFLOW executables from the MODFLOW-USGS/executables repository
+inputs:
+  path:
+    description: Path to store the executables (e.g. a bin directory)
+    required: true
+    default: bin
+  github_token:
+    description: GitHub API access token
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install FloPy
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        # TODO use version on PyPI when release with get-modflow is out
+        pip install https://github.com/modflowpy/flopy/zipball/develop
+
+    - name: Install FloPy
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        # TODO use version on PyPI when release with get-modflow is out
+        pip install https://github.com/modflowpy/flopy/zipball/develop
+
+    - name: Make bin directory
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.path }}
+
+    - name: Make bin directory (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        md -Force ${{ inputs.path }}
+
+    - name: Check release
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        # get info for the executables repository's latest release
+        release_json=$(gh api -X GET -H "Accept: application/vnd.github+json" /repos/MODFLOW-USGS/executables/releases/latest)
+        # get asset ID of the release's metadata file, if one exists
+        get_asset_id="
+        import json
+        import sys
+        release = json.load(sys.stdin, strict=False)
+        metadata = next(iter([a for a in release['assets'] if a['name'] == 'code.json']), None)
+        print(dict(metadata)['id'] if metadata else '')
+        "
+        asset_id=$(echo "$release_json" | python -c "$get_asset_id")
+        # asset_id is empty if metadata file asset wasn't found
+        if [ ${#asset_id} -gt 0 ]; then
+           gh api -H "Accept: application/octet-stream" "/repos/MODFLOW-USGS/executables/releases/assets/$asset_id" >> executables.json
+        else
+          # give hashFiles an empty file to hash
+          touch executables.json
+        fi
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
+    - name: Check release (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        # get info for the executables repository's latest release
+        $release_json=(gh api -X GET -H "Accept: application/vnd.github+json" /repos/MODFLOW-USGS/executables/releases/latest)
+        # get asset ID of the release's metadata file, if one exists
+        $pattern="code.json"
+        $release=(echo $release_json | ConvertFrom-Json)
+        $asset_id=($release.assets | Where-Object {$_.name -match "$pattern"} | % {echo $_.id})
+        # asset_id is empty if metadata file asset wasn't found
+        if ($asset_id.Length -gt 0) {
+          gh api -H "Accept: application/octet-stream" "/repos/MODFLOW-USGS/executables/releases/assets/$asset_id" >> executables.json
+        } else {
+          # give hashFiles an empty file to hash
+          New-Item -Name "executables.json" -ItemType File
+        }
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+
+    - name: Cache executables
+      id: cache_executables
+      uses: actions/cache@v3
+      with:
+        path: ${{ inputs.path }}
+        key: modflow-exes-${{ runner.os }}-${{ hashFiles('executables.json') }}
+
+    - name: Install executables
+      if: runner.os != 'Windows' && steps.cache_executables.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        get-modflow ${{ inputs.path }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+
+    - name: Install executables (Windows)
+      if: runner.os == 'Windows' && steps.cache_executables.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        get-modflow ${{ inputs.path }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+
+    - name: Add executables to path
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        echo ${{ inputs.path }} >> $GITHUB_PATH
+
+    - name: Add executables to path (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        echo ${{ inputs.path }} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/scripts/verify_install.py
+++ b/scripts/verify_install.py
@@ -1,0 +1,84 @@
+from os import environ
+from pathlib import Path
+from platform import system
+from pprint import pprint
+import requests
+from shutil import which
+import sys
+
+
+def get_expected_files():
+    api_url = environ.get("GITHUB_API_URL")
+    if not api_url:
+        api_url = "https://api.github.com"
+
+    token = environ.get("GITHUB_TOKEN")
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    # check release assets for code.json
+    response = requests.get(f"{api_url}/repos/MODFLOW-USGS/executables/releases/latest", headers=headers)
+    release = response.json()
+    metadata = next(iter([a for a in release['assets'] if a['name'] == 'code.json']), None)
+
+    if metadata:
+        # TODO download code.json (once added to release assets)
+        exp = []
+        pass
+    else:
+        exp = [
+            'sutra',
+            'mp6',
+            'mp7',
+            'swtv4',
+            'mf6',
+            'mt3dusgs',
+            'zbud6',
+            'zonbudusg',
+            'mfusg',
+            'mfnwtdbl',
+            'crt',
+            'gsflow',
+            'mt3dms',
+            'mf2005dbl',
+            'zonbud3',
+            'gridgen',
+            'mflgrdbl',
+            'mfnwt',
+            'mf2005',
+            'vs2dt',
+            'mflgr',
+            'mf2000',
+            'triangle',
+            'mfusgdbl',
+        ]
+
+    if system() == "Windows":
+        exp = [f"{exe}.exe" for exe in exp]
+    else:
+        # TODO remove if PRMS is added to Windows distribution
+        exp += ["prms"]
+
+    return exp
+
+
+path = Path(sys.argv[1])
+if not path:
+    raise ValueError(f"Must specify install location")
+
+# check install location exists
+assert path.is_dir()
+print(f"Found install location: {path}")
+
+# check executables exist
+found = sorted([p.name for p in path.glob("*")])
+expected = sorted(get_expected_files())
+assert set(found) >= set(expected)
+print(f"Found all expected executables:")
+pprint(expected)
+
+# check executables are on the PATH
+for exe in expected:
+    assert which(exe)
+print(f"Verified executables are on system path")


### PR DESCRIPTION
Sample test run: https://github.com/w-bonelli/install-modflow-action/actions/runs/3009387987

This action depends on FloPy's new `get-modflow` utility &mdash; as a temporary solution FloPy is currently installed via zipball from the develop branch, and the action is still defined as a [composite action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action). To avoid version conflicts between the FloPy installed here and the one in whichever repo uses this, I think it's necessary to use a [Docker container action](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action). (Composite definitions should be sufficient for the fortran install actions because they don't use FloPy or any Python.)

I've marked this ready in order to be able to create an initial release and check that it works as expected when referenced from another repo with e.g. `uses: modflowpy/install-modflow-action@v0`. I can package it up with Docker in a followup PR.