### PR TITLE
fix(paths): fix bin path handling, misc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         gm: [flopy, standalone]
         repo: [executables, modflow6, modflow6-nightly-build]
+        path: [absolute, relative, tilde]
     defaults:
       run:
         shell: bash
@@ -35,16 +36,30 @@ jobs:
         if: matrix.gm == 'flopy'
         run: |
           pip install git+https://github.com/modflowpy/flopy.git
-      - name: Set bin directory
+      - name: Set bin path
         if: runner.os != 'Windows'
         run: |
-          bindir="$HOME/.local/bin"
+          if [ "${{ matrix.path }}" == "absolute" ]; then
+            bindir="$HOME/.local/bin"
+          elif [ "${{ matrix.path }}" == "relative" ]; then
+            bindir="bin"
+          else
+            bindir="~/.local/bin"
+          fi
+
           echo "TEST_BINDIR=$bindir" >> $GITHUB_ENV
-      - name: Set bin directory
+      - name: Set bin path (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $bindir = "C:\Users\runneradmin\.local\bin"
+          if ("${{ matrix.path }}" -eq "absolute") {
+            $bindir = "C:\Users\runneradmin\.local\bin"
+          } elseif ("${{ matrix.path }}" -eq "relative") {
+            $bindir = "bin"
+          } else {
+            $bindir = "~/.local/bin"
+          }
+
           echo "TEST_BINDIR=$bindir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install executables
         id: install_executables
@@ -56,7 +71,6 @@ jobs:
       - name: Test installation
         run: |
           script_path="$RUNNER_TEMP/get_modflow.py"
-          bin_path="$HOME/.local/bin"
 
           if [ ${{ matrix.gm }} == "standalone" ] && [ ${{ steps.install_executables.outputs.cache-hit }} != "true" ]
           then
@@ -69,6 +83,6 @@ jobs:
             fi
           fi
 
-          python test/test_exes.py $bin_path ${{ matrix.repo }}
+          python test/test_exes.py $TEST_BINDIR ${{ matrix.repo }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # install-modflow-action
 
-[![CI](https://github.com/modflowpy/install-modflow-action/actions/workflows/commit.yml/badge.svg?branch=develop)](https://github.com/modflowpy/install-modflow-action/actions/workflows/commit.yml)
+[![CI](https://github.com/modflowpy/install-modflow-action/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/modflowpy/install-modflow-action/actions/workflows/ci.yml)
 
 An action to install MODFLOW 6 and related programs.
 
@@ -14,6 +14,8 @@ An action to install MODFLOW 6 and related programs.
     - [`github_token`](#github_token)
     - [`path`](#path)
     - [`repo`](#repo)
+  - [Outputs](#outputs)
+    - [`cache-hit`](#cache-hit)
 - [MODFLOW Resources](#modflow-resources)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -52,9 +54,7 @@ The example above uses the [automatically provided](https://docs.github.com/en/a
 
 #### `path`
 
-The `path` input is the location to install executables, e.g. a local bin directory.
-
-**Note**: tilde expansion only works on Linux and Mac runners. The example above is suitable for Linux and Mac &mdash; on Windows a similar location might be `C:\Users\runneradmin\.local\bin`.
+The `path` input is the location to install executables. The path may be absolute or relative to the workflow's working directory. Tilde expansion is also supported on all three major platforms. The resolved path is stored in the `MODFLOW_BIN_PATH` environment variable, which is then available to subsequent workflow steps.
 
 #### `repo`
 
@@ -63,6 +63,21 @@ The `repo` input allows selecting which MODFLOW 6 executable distribution to ins
 - `executables` (default)
 - `modflow6`
 - `modflow6-nightly-build`
+
+### Outputs
+
+The action has the following outputs:
+
+- `cache-hit`
+
+#### `cache-hit`
+
+The `cache-hit` output simply forwards the internal `actions/cache` output of the same name, and is `true` if a matching entry was found and `false` if not.
+
+Cache keys follow pattern `modflow-${{ runner.os }}-${{ inputs.repo }}-${{ hashFiles('code.json') }}`, where `code.json` is a JSON file containing version metadata. (This file is currently distributed only with the `executables` distribution, but is to be added to the others in forthcoming releases.) Thus separate caches are maintained for each combination of platform and distribution repository, and the cache is invalidated
+
+1. when `code.json` changes, or
+2. when `code.json` is added to a distribution.
 
 ## MODFLOW Resources
 

--- a/action.yml
+++ b/action.yml
@@ -1,36 +1,36 @@
-name: Install MODFLOW executables
-description: Install & cache MODFLOW executables from the MODFLOW-USGS/executables repository
+name: Install MODFLOW
+description: Install & cache MODFLOW 6 and related programs.
 inputs:
-  path:
-    description: Path to store the executables (e.g. a bin directory)
-    required: true
   github_token:
     description: GitHub API access token
     required: true
+  path:
+    description: Path to store the executables (e.g. a bin directory)
+    required: true
   repo:
-    description: The repository to install executables from ('executables', 'modflow6', or 'modflow6-nightly-build')
+    description: Repository to install executables from ('executables', 'modflow6', or 'modflow6-nightly-build')
     required: false
     default: executables
 outputs:
   cache-hit:
-    description: Whether MODFLOW executables were restored from the cache.
+    description: Whether a matching entry was found in the Github Actions cache
     value: ${{ steps.cache_executables.outputs.cache-hit }}
 runs:
   using: composite
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-
-    - name: Create bin directory
+    - if: runner.os != 'Windows'
       shell: bash
       run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          mkdir -p "${{ inputs.path }}"
-        else
-          mkdir -p ${{ inputs.path }}
-        fi
+        normalized=$(python3 $GITHUB_ACTION_PATH/normalize_path.py "${{ inputs.path }}")
+        echo "MODFLOW_BIN_PATH=$normalized" >> $GITHUB_ENV
+        mkdir -p "$normalized"
+
+    - if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $normalized = $(python3 $(Join-Path -Path "$env:GITHUB_ACTION_PATH" -ChildPath "normalize_path.py") "${{ inputs.path }}")
+        echo "MODFLOW_BIN_PATH=$normalized" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+        md -Force "$normalized"
 
     - name: Check release
       shell: bash
@@ -47,7 +47,7 @@ runs:
         metadata = next(iter([a for a in release['assets'] if a['name'] == pattern]), None)
         print(dict(metadata)['id'] if metadata else '')
         "
-        asset_id=$(echo "$release_json" | python -c "$get_asset_id") || echo "No release to check, skipping"
+        asset_id=$(echo "$release_json" | python3 -c "$get_asset_id") || echo "No release to check, skipping"
 
         # asset_id is empty if metadata file asset wasn't found
         if [ ${#asset_id} -gt 0 ]; then
@@ -63,8 +63,8 @@ runs:
       id: cache_executables
       uses: actions/cache@v3
       with:
-        path: ${{ inputs.path }}
-        key: modflow-exes-${{ runner.os }}-${{ inputs.repo }}-${{ hashFiles('code.json') }}
+        path: ${{ env.MODFLOW_BIN_PATH }}
+        key: modflow-${{ runner.os }}-${{ inputs.repo }}-${{ hashFiles('code.json') }}
 
     - name: Install executables
       if: steps.cache_executables.outputs.cache-hit != 'true'
@@ -72,23 +72,15 @@ runs:
       run: |
         if command -v get-modflow &> /dev/null
         then
-          echo "get-modflow command is available (FloPy is probably installed)"
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            get-modflow "${{ inputs.path }}" --repo ${{ inputs.repo }}
-          else
-            get-modflow ${{ inputs.path }} --repo ${{ inputs.repo }}
-          fi
+          echo "get-modflow command is available, running get-modflow"
+          get-modflow "$MODFLOW_BIN_PATH" --repo ${{ inputs.repo }}
         else
-          echo "downloading get-modflow script"
+          echo "get-modflow command not available, downloading get_modflow.py"
           script_path="$RUNNER_TEMP/get_modflow.py"
-
           curl https://raw.githubusercontent.com/modflowpy/flopy/develop/flopy/utils/get_modflow.py -o "$script_path"
 
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            python $script_path "${{ inputs.path }}" --repo "${{ inputs.repo }}"
-          else
-            python $script_path ${{ inputs.path }} --repo "${{ inputs.repo }}"
-          fi
+          echo "running get_modflow.py"
+          python3 $script_path "$MODFLOW_BIN_PATH" --repo "${{ inputs.repo }}"
         fi
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
@@ -97,12 +89,12 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        normalized="`cd "${{ inputs.path }}";pwd`"
-        echo "$normalized" >> $GITHUB_PATH
+        echo "adding bin dir '$MODFLOW_BIN_PATH' to path"
+        echo "$MODFLOW_BIN_PATH" >> $GITHUB_PATH
 
     - name: Add executables to path (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $normalized = $(Resolve-Path ${{ inputs.path }}).ToString()
-        echo $normalized | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "adding bin dir '$env:MODFLOW_BIN_PATH' to path"
+        echo $env:MODFLOW_BIN_PATH | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ runs:
       shell: bash
       run: |
         normalized=$(python3 $GITHUB_ACTION_PATH/normalize_path.py "${{ inputs.path }}")
+        echo "Normalized bin dir path: $normalized"
         echo "MODFLOW_BIN_PATH=$normalized" >> $GITHUB_ENV
         mkdir -p "$normalized"
 
@@ -29,6 +30,7 @@ runs:
       shell: pwsh
       run: |
         $normalized = $(python3 $(Join-Path -Path "$env:GITHUB_ACTION_PATH" -ChildPath "normalize_path.py") "${{ inputs.path }}")
+        echo "Normalized bin dir path: $normalized"
         echo "MODFLOW_BIN_PATH=$normalized" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
         md -Force "$normalized"
 

--- a/normalize_path.py
+++ b/normalize_path.py
@@ -1,10 +1,11 @@
 import os
 import sys
+from pathlib import Path
 
 path = sys.argv[1]
-if path.startswith('/'):
-    print(path)
+if path.startswith('/') or path.startswith('\\'):
+    print(Path(path).resolve())
 elif path.startswith('~'):
-    print(os.path.expanduser(path))
+    print(Path(os.path.expanduser(path)).resolve())
 else:
-    print(os.path.realpath(os.path.join(os.getcwd(), path)))
+    print(os.path.realpath(Path(path).resolve()))

--- a/normalize_path.py
+++ b/normalize_path.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+path = sys.argv[1]
+if path.startswith('/'):
+    print(path)
+elif path.startswith('~'):
+    print(os.path.expanduser(path))
+else:
+    print(os.path.realpath(os.path.join(os.getcwd(), path)))

--- a/test/test_exes.py
+++ b/test/test_exes.py
@@ -6,7 +6,7 @@ import requests
 from shutil import which
 import sys
 
-path = Path(sys.argv[1])
+path = Path(sys.argv[1]).expanduser().absolute()
 if not path:
     raise ValueError(f"Must specify install location")
 

--- a/test/test_exes.py
+++ b/test/test_exes.py
@@ -103,3 +103,8 @@ pprint(expected)
 for exe in expected:
     assert which(exe), f"Executable {exe} not found on path"
 print(f"Verified executables are on system path")
+
+# check bin path environment variable is set
+env_var = environ.get("MODFLOW_BIN_PATH")
+assert env_var
+assert Path(env_var).is_dir()


### PR DESCRIPTION
Adds support for tilde expansion on Windows and addresses path resolution issues (e.g. [here](https://github.com/aleaf/python-for-hydrology/actions/runs/3218108633/jobs/5261873576#step:7:112)). Aims to make behavior more consistent by supporting absolute, relative and tilde-expanded paths on all 3 platforms. Adds an output `cache-hit` indicating whether the cache was restored. Stores an environment variable `MODFLOW_BIN_PATH` pointing to the install directory. Updates `README.md` with info about above, as well as cache key pattern and `code.json` invalidation scheme.