### PR TITLE
refactor(inputs): make required inputs optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        gm: [flopy, standalone]
-        repo: [executables, modflow6, modflow6-nightly-build]
-        path: [absolute, relative, tilde]
+        gm: [ flopy, standalone ]
+        repo: [ executables, modflow6, modflow6-nightly-build ]
+        path: [ absolute, relative, tilde ]
     defaults:
       run:
         shell: bash
@@ -43,8 +43,11 @@ jobs:
             bindir="$HOME/.local/bin"
           elif [ "${{ matrix.path }}" == "relative" ]; then
             bindir="bin"
-          else
+          elif [ "${{ matrix.path }}" == "tilde" ]; then
             bindir="~/.local/bin"
+          else
+            echo "unexpected option ${{ matrix.path }}"
+            exit 1
           fi
 
           echo "TEST_BINDIR=$bindir" >> $GITHUB_ENV
@@ -56,23 +59,25 @@ jobs:
             $bindir = "C:\Users\runneradmin\.local\bin"
           } elseif ("${{ matrix.path }}" -eq "relative") {
             $bindir = "bin"
-          } else {
+          } elseif ("${{ matrix.path }}" -eq "tilde") {
             $bindir = "~/.local/bin"
+          } else {
+            echo "unexpected option ${{ matrix.path }}"
+            exit 1
           }
 
           echo "TEST_BINDIR=$bindir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install executables
-        id: install_executables
+        id: install-executables
         uses: ./
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ env.TEST_BINDIR }}
           repo: ${{ matrix.repo }}
       - name: Test installation
         run: |
           script_path="$RUNNER_TEMP/get_modflow.py"
 
-          if [ ${{ matrix.gm }} == "standalone" ] && [ ${{ steps.install_executables.outputs.cache-hit }} != "true" ]
+          if [ ${{ matrix.gm }} == "standalone" ] && [ ${{ steps.install-executables.outputs.cache-hit }} != "true" ]
           then
             if [ -f "$script_path" ]
             then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contributing](#contributing)
+  - [Issues and features](#issues-and-features)
+  - [Pull requests](#pull-requests)
+  - [Commit messages](#commit-messages)
+    - [Type](#type)
+    - [Scope](#scope)
+    - [Subject](#subject)
+    - [Body](#body)
+    - [Footer](#footer)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Contributing
 
 Contributions to this repository are welcome. To make a contribution we ask that you follow a few guidelines.

--- a/README.md
+++ b/README.md
@@ -33,28 +33,25 @@ To use this action, add a step like the following to your workflow:
 ```yaml
 - name: Install MODFLOW 6
   uses: modflowpy/install-modflow-action@v1
-  with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-    path: ~/.local/bin
 ```
 
 ### Inputs
 
-The action accepts the following inputs:
+The action accepts the following optional inputs:
 
-- `github_token` (required)
-- `path` (required)
-- `repo` (optional)
+- `path`
+- `repo`
+- `github_token`
 
 #### `github_token`
 
-Because composite GitHub Actions [do not have access to secrets](https://stackoverflow.com/a/70111134/6514033), a GitHub API token must be provided via the `github_token` input (this avoids HTTP errors due to rate-limiting).
-
-The example above uses the [automatically provided](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) `GITHUB_TOKEN` secret, but a personal access token may be provided as well.
+By default, the action uses the [automatically provided](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) `GITHUB_TOKEN` secret, but an access token may be explicitly provided as well.
 
 #### `path`
 
 The `path` input is the location to install executables. The path may be absolute or relative to the workflow's working directory. Tilde expansion is also supported on all three major platforms. The resolved path is stored in the `MODFLOW_BIN_PATH` environment variable, which is then available to subsequent workflow steps.
+
+The default path, shared on all three platforms, is `~/.local/bin/modflow`.
 
 #### `repo`
 

--- a/action.yml
+++ b/action.yml
@@ -1,24 +1,26 @@
 name: Install MODFLOW
 description: Install & cache MODFLOW 6 and related programs.
 inputs:
-  github_token:
-    description: GitHub API access token
-    required: true
   path:
-    description: Path to store the executables (e.g. a bin directory)
-    required: true
+    description: Path to install location (e.g. a bin directory)
+    required: false
+    default: ~/.local/bin/modflow
   repo:
     description: Repository to install executables from ('executables', 'modflow6', or 'modflow6-nightly-build')
     required: false
     default: executables
+  github_token:
+    description: GitHub API access token
+    required: false
 outputs:
   cache-hit:
-    description: Whether a matching entry was found in the Github Actions cache
-    value: ${{ steps.cache_executables.outputs.cache-hit }}
+    description: Whether the installation was restored from cache
+    value: ${{ steps.cache-modflow.outputs.cache-hit }}
 runs:
   using: composite
   steps:
-    - if: runner.os != 'Windows'
+    - name: Set install path variable
+      if: runner.os != 'Windows'
       shell: bash
       run: |
         normalized=$(python3 $GITHUB_ACTION_PATH/normalize_path.py "${{ inputs.path }}")
@@ -26,13 +28,26 @@ runs:
         echo "MODFLOW_BIN_PATH=$normalized" >> $GITHUB_ENV
         mkdir -p "$normalized"
 
-    - if: runner.os == 'Windows'
+    - name: Set install path variable (Windows)
+      if: runner.os == 'Windows'
       shell: pwsh
       run: |
         $normalized = $(python3 $(Join-Path -Path "$env:GITHUB_ACTION_PATH" -ChildPath "normalize_path.py") "${{ inputs.path }}")
         echo "Normalized bin dir path: $normalized"
         echo "MODFLOW_BIN_PATH=$normalized" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
         md -Force "$normalized"
+
+    - name: Set github token
+      id: set-github-token
+      shell: bash
+      run: |
+        if [ "${{ inputs.github_token }}" == "" ]; then
+          token="${{ github.token }}"
+        else
+          token="${{ inputs.github_token }}"
+        fi
+        
+        echo "token=$token" >> $GITHUB_OUTPUT
 
     - name: Check release
       shell: bash
@@ -59,17 +74,17 @@ runs:
           touch code.json
         fi
       env:
-        GH_TOKEN: ${{ inputs.github_token }}
+        GH_TOKEN: ${{ steps.set-github-token.outputs.token }}
 
     - name: Cache executables
-      id: cache_executables
+      id: cache-modflow
       uses: actions/cache@v3
       with:
         path: ${{ env.MODFLOW_BIN_PATH }}
         key: modflow-${{ runner.os }}-${{ inputs.repo }}-${{ hashFiles('code.json') }}
 
     - name: Install executables
-      if: steps.cache_executables.outputs.cache-hit != 'true'
+      if: steps.cache-modflow.outputs.cache-hit != 'true'
       shell: bash
       run: |
         if command -v get-modflow &> /dev/null
@@ -85,7 +100,7 @@ runs:
           python3 $script_path "$MODFLOW_BIN_PATH" --repo "${{ inputs.repo }}"
         fi
       env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ steps.set-github-token.outputs.token }}
 
     - name: Add executables to path
       if: runner.os != 'Windows'


### PR DESCRIPTION
Makes `github_token` and `path` inputs optional. (They were previously required.)

#### `github_token`

I was under the impression the token needed to be explicitly provided, since [actions don't have access to repository secrets](), but it turns out [actions can access the automatically provided token with the `github` context](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), e.g. `${{ github.token }}`.

#### `path`

The default location is now `~/.local/bin/modflow` on all platforms. (Tilde expansion resolves the runner's home directory.)