### PR TITLE
fix(path): fix default install path, add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         gm: [ flopy, standalone ]
         repo: [ executables, modflow6, modflow6-nightly-build ]
-        path: [ absolute, relative, tilde ]
+        path: [ absolute, relative, tilde, empty ]
     defaults:
       run:
         shell: bash
@@ -46,8 +46,7 @@ jobs:
           elif [ "${{ matrix.path }}" == "tilde" ]; then
             bindir="~/.local/bin"
           else
-            echo "unexpected option ${{ matrix.path }}"
-            exit 1
+            bindir=""
           fi
 
           echo "TEST_BINDIR=$bindir" >> $GITHUB_ENV
@@ -62,8 +61,7 @@ jobs:
           } elseif ("${{ matrix.path }}" -eq "tilde") {
             $bindir = "~/.local/bin"
           } else {
-            echo "unexpected option ${{ matrix.path }}"
-            exit 1
+            $bindir = ""
           }
 
           echo "TEST_BINDIR=$bindir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
@@ -88,6 +86,6 @@ jobs:
             fi
           fi
 
-          python test/test_exes.py $TEST_BINDIR ${{ matrix.repo }}
+          python test/test_exes.py "$TEST_BINDIR" "${{ matrix.repo }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   path:
     description: Path to install location (e.g. a bin directory)
     required: false
-    default: ~/.local/bin/modflow
+    default: "~/.local/bin/modflow"
   repo:
     description: Repository to install executables from ('executables', 'modflow6', or 'modflow6-nightly-build')
     required: false
@@ -23,7 +23,9 @@ runs:
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        normalized=$(python3 $GITHUB_ACTION_PATH/normalize_path.py "${{ inputs.path }}")
+        path="${{ inputs.path }}"
+        path=${path:="~/.local/bin/modflow"}
+        normalized=$(python3 $GITHUB_ACTION_PATH/normalize_path.py "$path")
         echo "Normalized bin dir path: $normalized"
         echo "MODFLOW_BIN_PATH=$normalized" >> $GITHUB_ENV
         mkdir -p "$normalized"
@@ -32,7 +34,9 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $normalized = $(python3 $(Join-Path -Path "$env:GITHUB_ACTION_PATH" -ChildPath "normalize_path.py") "${{ inputs.path }}")
+        $path = "${{ inputs.path }}"
+        $path = $(if ($path) { $path } else { "~/.local/bin/modflow" })
+        $normalized = $(python3 $(Join-Path -Path "$env:GITHUB_ACTION_PATH" -ChildPath "normalize_path.py") "$path")
         echo "Normalized bin dir path: $normalized"
         echo "MODFLOW_BIN_PATH=$normalized" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
         md -Force "$normalized"

--- a/test/test_exes.py
+++ b/test/test_exes.py
@@ -6,13 +6,8 @@ import requests
 from shutil import which
 import sys
 
-path = Path(sys.argv[1]).expanduser().absolute()
-if not path:
-    raise ValueError(f"Must specify install location")
-
-repo = sys.argv[2]
-if not repo:
-    repo = "executables"
+path = Path(sys.argv[1] if sys.argv[1] else "~/.local/bin/modflow").expanduser().absolute()
+repo = sys.argv[2] if (len(sys.argv) > 1 and sys.argv[2]) else "executables"
 
 print(f"Path: {path}")
 print(f"Repo: {repo}")


### PR DESCRIPTION
Handle empty `path` input and add tests to make sure we fall back to the default `~/.local/bin/modflow`