### PR TITLE
refactor: use RUNNER_TEMP for code.json download/check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+          cache: 'pip'
 
       - name: Install Python dependencies
         run: pip install -r test/requirements.txt

--- a/action.yml
+++ b/action.yml
@@ -75,17 +75,18 @@ runs:
         "
         asset_id=$(echo "$release_json" | python3 -c "$get_asset_id") || echo "No release to check, skipping"
         code_json="$RUNNER_TEMP/code.json"
+        echo "Using temporary code.json path: $code_json"
         echo "code_json=$code_json" >> $GITHUB_OUTPUT
 
         # asset_id is empty if code.json asset wasn't found on the release
         if [ ${#asset_id} -gt 0 ]; then
-          curl -H "Accept: application/octet-stream" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/MODFLOW-USGS/${{ inputs.repo }}/releases/assets/$asset_id" >> $code_json
-          echo "Found code.json for distribution '${{ inputs.repo }}' with contents:"
-          cat $code_json
+          curl -H "Accept: application/octet-stream" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/MODFLOW-USGS/${{ inputs.repo }}/releases/assets/$asset_id" >> "$code_json"
+          echo "Found code.json (asset ID '$asset_id') for distribution '${{ inputs.repo }}' with contents:"
+          cat "$code_json"
         else
           # give hashFiles an empty file
           echo "No code.json found for distribution '${{ inputs.repo }}', creating empty file"
-          touch $code_json
+          touch "$code_json"
         fi
       env:
         GH_TOKEN: ${{ steps.set-github-token.outputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -65,23 +65,23 @@ runs:
         release_json=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/MODFLOW-USGS/${{ inputs.repo }}/releases/latest") || echo "No release to check, skipping"
 
         # get asset ID of the release's metadata file, if one exists
-        get_asset_id="
+        get_download_url="
         import json
         import sys
         pattern = 'code.json'
         release = json.load(sys.stdin, strict=False)
         metadata = next(iter([a for a in release['assets'] if a['name'] == pattern]), None)
-        print(dict(metadata)['id'] if metadata else '')
+        print(dict(metadata)['browser_download_url'] if metadata else '')
         "
-        asset_id=$(echo "$release_json" | python3 -c "$get_asset_id") || echo "No release to check, skipping"
+        download_url=$(echo "$release_json" | python3 -c "$get_download_url") || echo "No release to check, skipping"
         code_json="$RUNNER_TEMP/code.json"
-        echo "Using temporary code.json path: $code_json"
         echo "code_json=$code_json" >> $GITHUB_OUTPUT
 
         # asset_id is empty if code.json asset wasn't found on the release
-        if [ ${#asset_id} -gt 0 ]; then
-          curl -H "Accept: application/octet-stream" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/MODFLOW-USGS/${{ inputs.repo }}/releases/assets/$asset_id" >> "$code_json"
-          echo "Found code.json (asset ID '$asset_id') for distribution '${{ inputs.repo }}' with contents:"
+        if [[ -n "$download_url" ]]; then
+          echo "Downloading code.json from $download_url to $code_json"
+          curl -L -H "Authorization: Bearer $GH_TOKEN" "$download_url" >> "$code_json"
+          echo "Found code.json for distribution '${{ inputs.repo }}' with contents:"
           cat "$code_json"
         else
           # give hashFiles an empty file

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,7 @@ runs:
         echo "token=$token" >> $GITHUB_OUTPUT
 
     - name: Check release
+      id: check-release
       shell: bash
       run: |
         # get info for the executables repository's latest release
@@ -73,16 +74,18 @@ runs:
         print(dict(metadata)['id'] if metadata else '')
         "
         asset_id=$(echo "$release_json" | python3 -c "$get_asset_id") || echo "No release to check, skipping"
+        code_json="$RUNNER_TEMP/code.json"
+        echo "code_json=$code_json" >> $GITHUB_OUTPUT
 
-        # asset_id is empty if metadata file asset wasn't found
+        # asset_id is empty if code.json asset wasn't found on the release
         if [ ${#asset_id} -gt 0 ]; then
-          curl -H "Accept: application/octet-stream" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/MODFLOW-USGS/${{ inputs.repo }}/releases/assets/$asset_id" >> code.json
-          echo "Found code.json for ${{ inputs.repo }} distribution with contents:"
-          cat code.json
+          curl -H "Accept: application/octet-stream" -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/repos/MODFLOW-USGS/${{ inputs.repo }}/releases/assets/$asset_id" >> $code_json
+          echo "Found code.json for distribution '${{ inputs.repo }}' with contents:"
+          cat $code_json
         else
-          # give hashFiles an empty file to hash
-          echo "No code.json found for ${{ inputs.repo }} distribution, creating empty file"
-          touch code.json
+          # give hashFiles an empty file
+          echo "No code.json found for distribution '${{ inputs.repo }}', creating empty file"
+          touch $code_json
         fi
       env:
         GH_TOKEN: ${{ steps.set-github-token.outputs.token }}
@@ -99,7 +102,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.MODFLOW_BIN_PATH }}
-        key: modflow-${{ runner.os }}-${{ inputs.repo }}-${{ hashFiles('code.json') }}-${{ steps.get-date.outputs.date }}
+        key: modflow-${{ runner.os }}-${{ inputs.repo }}-${{ hashFiles(steps.check-release.outputs.code_json) }}-${{ steps.get-date.outputs.date }}
 
     - name: Install executables
       if: inputs.cache != 'true' || steps.cache-modflow.outputs.cache-hit != 'true'


### PR DESCRIPTION
- The action checks the Releases API for a `code.json` asset and downloads then hashes it to determine whether to refresh the cache (this happens daily anyways, but checking `code.json` allows automatically detecting and using new versions immediately when they are released). Previously `code.json` was downloaded to the working directory, i.e. [`${{ github.workspace }}`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context). Switch the download location to `$RUNNER_TEMP/code.json` to avoid altering the job's workspace

- The `code.json` download can fail [using asset ID and header `Accept: application/octet-stream`](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#get-a-release-asset). Retrieve and use the asset's `browser_download_url` instead

- Cache Python dependencies to speed up CI